### PR TITLE
Rename `RemoteFeedLoaderTests` to reflect the use case it refers to (…

### DIFF
--- a/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		363E88A629CA7A9C0077E089 /* EssentialFeed.h in Headers */ = {isa = PBXBuildFile; fileRef = 363E889829CA7A9B0077E089 /* EssentialFeed.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		363E88B029CA7B450077E089 /* FeedItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363E88AF29CA7B450077E089 /* FeedItem.swift */; };
 		363E88B229CA927B0077E089 /* FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363E88B129CA927B0077E089 /* FeedLoader.swift */; };
-		363E88B529CCDE650077E089 /* RemoteFeedLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363E88B429CCDE650077E089 /* RemoteFeedLoaderTests.swift */; };
+		363E88B529CCDE650077E089 /* LoadFeedFromRemoteUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363E88B429CCDE650077E089 /* LoadFeedFromRemoteUseCaseTests.swift */; };
 		363E88B829CD2CE60077E089 /* RemoteFeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363E88B729CD2CE60077E089 /* RemoteFeedLoader.swift */; };
 		363E88BA29CFAECB0077E089 /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363E88B929CFAECB0077E089 /* HTTPClient.swift */; };
 		363E88BC29CFAF220077E089 /* FeedItemsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363E88BB29CFAF220077E089 /* FeedItemsMapper.swift */; };
@@ -48,7 +48,7 @@
 		363E889F29CA7A9C0077E089 /* EssentialFeedTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialFeedTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		363E88AF29CA7B450077E089 /* FeedItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedItem.swift; sourceTree = "<group>"; };
 		363E88B129CA927B0077E089 /* FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoader.swift; sourceTree = "<group>"; };
-		363E88B429CCDE650077E089 /* RemoteFeedLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeedLoaderTests.swift; sourceTree = "<group>"; };
+		363E88B429CCDE650077E089 /* LoadFeedFromRemoteUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadFeedFromRemoteUseCaseTests.swift; sourceTree = "<group>"; };
 		363E88B729CD2CE60077E089 /* RemoteFeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeedLoader.swift; sourceTree = "<group>"; };
 		363E88B929CFAECB0077E089 /* HTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
 		363E88BB29CFAF220077E089 /* FeedItemsMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedItemsMapper.swift; sourceTree = "<group>"; };
@@ -149,7 +149,7 @@
 			isa = PBXGroup;
 			children = (
 				367C43AA29D5118C008CFC31 /* Helpers */,
-				363E88B429CCDE650077E089 /* RemoteFeedLoaderTests.swift */,
+				363E88B429CCDE650077E089 /* LoadFeedFromRemoteUseCaseTests.swift */,
 				363E88BF29D2729C0077E089 /* URLSessionHTTPClientTests.swift */,
 			);
 			path = "Feed API";
@@ -323,7 +323,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				363E88B529CCDE650077E089 /* RemoteFeedLoaderTests.swift in Sources */,
+				363E88B529CCDE650077E089 /* LoadFeedFromRemoteUseCaseTests.swift in Sources */,
 				363E88C029D2729C0077E089 /* URLSessionHTTPClientTests.swift in Sources */,
 				367C43AC29D511B3008CFC31 /* XCTTestCase+MemoryLeakTracking.swift in Sources */,
 			);

--- a/EssentialFeedTests/Feed API/LoadFeedFromRemoteUseCaseTests.swift
+++ b/EssentialFeedTests/Feed API/LoadFeedFromRemoteUseCaseTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 import EssentialFeed
 
-final class RemoteFeedLoaderTests: XCTestCase {
+final class LoadFeedFromRemoteUseCaseTests: XCTestCase {
 
     func test_init_doesNotRequestDataFromURL() {
         let (_, client) = makeSUT()


### PR DESCRIPTION
…Load Feed From Remote)